### PR TITLE
ECS-8: Added EC2 deployment yml workflow and Dockerfile port exposure

### DIFF
--- a/.github/workflows/deploy_to_ec2.yml
+++ b/.github/workflows/deploy_to_ec2.yml
@@ -1,0 +1,43 @@
+name: Deploy Python API Docker Image to EC2 and run it
+
+on:
+  push:
+    branches:
+      - main  
+
+env:
+  DOCKER_IMAGE: yourdockerhubusername/myapp:latest  # needs one of our docker hub usernames 
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }} # we need to setup secrets in the repo settings
+
+      - name: Build python api image
+        run: docker build -t $DOCKER_IMAGE .
+
+      - name: Push python api docker image
+        run: docker push $DOCKER_IMAGE
+
+      - name: setup ssh agent to connect to EC2
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.EC2_SSH_KEY }} # we need to setup ec2 and get a secrets key
+
+      - name: SSH into EC2 and pull & run new docker image
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_HOST }} << 'EOF' # ec2 needs to have docker installed as a prereq
+            docker pull $DOCKER_IMAGE
+            docker stop myapp || true
+            docker rm myapp || true
+            docker run -d -p 80:5000 --name myapp $DOCKER_IMAGE
+          EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+EXPOSE 5000
+
 CMD ["python", "main.py"]


### PR DESCRIPTION
Added a workflow which deploys the python docker container to an EC2 instance triggered by a push to main branch. Added port exposure to Dockerfile to allow web access for the flask or fastapi app. 

**NOTE**:  It is mostly a template and needs some adjustments and we need to add the EC2 and Docker secrets to github secrets.
**NOTE**: Need to consider docker-compose file as well for frontend and backend containers.